### PR TITLE
Fix:清除重复定义的`namespace`属性

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     compileSdk = 33
-    namespace="cn.fkj233.ui"
+    namespace = "cn.fkj233.ui"
     defaultConfig {
         minSdk = 26
     }
@@ -27,7 +27,6 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_11.majorVersion
     }
-    namespace = "cn.fkj233.miui"
 }
 
 dependencies {


### PR DESCRIPTION
您在最近一条提交中增添了一条重复定义的 `namespace` 属性于 `build.gradle.kts` 中，现已清除错误的定义。